### PR TITLE
driveにtraQ avatar pluginを導入

### DIFF
--- a/nextcloud/Dockerfile
+++ b/nextcloud/Dockerfile
@@ -10,6 +10,12 @@ RUN git clone https://github.com/traPtitech/nc-trapauth.git /nc-trapauth
 WORKDIR /nc-trapauth
 RUN composer install
 
+RUN git clone https://github.com/traPtitech/nc-traq-avatar /traq_avatar
+
+WORKDIR /traq_avatar
+RUN composer install
+
 FROM nextcloud:${NEXTCLOUD_VERSION}-fpm
 
 COPY --from=build /nc-trapauth /usr/src/nextcloud/apps/nc-trapauth
+COPY --from=build /traq_avatar /usr/src/nextcloud/apps/traq_avatar


### PR DESCRIPTION
ログイン時にtraQのアバターを取りに行くプラグインができました

ログイン時に取りに行くので、ログアウトボタンを押せばアバターが上書きされて、上手くいけばtraQのものになります
<img width="1280" alt="スクリーンショット 2020-02-23 21 53 11" src="https://user-images.githubusercontent.com/18257693/75112935-4918e580-568c-11ea-87c7-cc2ee4f939b8.png">
<img width="1280" alt="スクリーンショット 2020-02-23 18 59 29" src="https://user-images.githubusercontent.com/18257693/75112937-4cac6c80-568c-11ea-8700-36ea84301ff4.png">

